### PR TITLE
docs: add AGENTS.md with project conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+This repository is a Claude Code plugin marketplace.
+
+## Project Structure
+
+```
+.claude-plugin/
+  marketplace.json   # Marketplace manifest listing all plugins
+plugins/
+  <plugin-name>/
+    .claude-plugin/
+      plugin.json    # Plugin manifest (name, description, version, etc.)
+    skills/
+      <skill-name>/
+        SKILL.md     # Skill definition with YAML frontmatter + instructions
+```
+
+## Conventions
+
+- **Commit messages**: Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`, `chore:`)
+- **Branching**: Create a feature branch from `main` for each change, then open a pull request
+- **Language**: Write all user-facing content (README, PR descriptions, etc.) in English
+
+## Adding a Plugin
+
+1. Create `plugins/<plugin-name>/.claude-plugin/plugin.json` with plugin metadata
+2. Create `plugins/<plugin-name>/skills/<skill-name>/SKILL.md` with skill instructions
+3. Add an entry to `.claude-plugin/marketplace.json` in the `plugins` array
+4. Validate with `/plugin validate .`
+
+## Validation
+
+After any changes to marketplace or plugin manifests, run:
+
+```
+/plugin validate .
+```
+
+Ensure validation passes without errors before committing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with project structure, conventions, and contribution guidelines for AI agents
- Add `CLAUDE.md` as a symlink to `AGENTS.md`

## Test plan
- [ ] Verify `CLAUDE.md` symlink resolves correctly
- [ ] Confirm conventions are picked up by Claude Code when working in this repo