### PR TITLE
fix: avoid backtick syntax in hello skill

### DIFF
--- a/plugins/hello-world/skills/hello/SKILL.md
+++ b/plugins/hello-world/skills/hello/SKILL.md
@@ -3,6 +3,4 @@ name: hello
 description: Greet the user by name
 ---
 
-Respond with `Hello <user name>!` where `<user name>` is the system user's name.
-
-Run `whoami` to get the user name.
+Run whoami to get the system user name, then respond with "Hello {user name}!" using the result.


### PR DESCRIPTION
## Summary
- Remove backticks from hello skill instructions to prevent Claude Code from interpreting them as dynamic content (`!`command``) syntax

## Test plan
- [x] Verified `/hello` works correctly after the fix