### PR TITLE
ci: add pull request CI with GitHub Actions linting

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,35 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  changed-files:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      github-actions: ${{ steps.changed-files.outputs.github-actions_any_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Detect changed files
+        id: changed-files
+        uses: tj-actions/changed-files@8cba46e29c11878d930bca7870bb54394d3e8b21 # v47.0.2
+        with:
+          files_yaml: |
+            github-actions:
+              - .github/**
+
+  check-github-actions:
+    needs: changed-files
+    if: needs.changed-files.outputs.github-actions == 'true'
+    uses: ./.github/workflows/reusable-check-github-actions.yaml
+    permissions:
+      contents: read

--- a/.github/workflows/reusable-check-github-actions.yaml
+++ b/.github/workflows/reusable-check-github-actions.yaml
@@ -1,0 +1,60 @@
+name: Check GitHub Actions
+
+on:
+  workflow_call:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Delete package.json
+        run: rm -f package.json
+
+      - name: Run actionlint
+        uses: raven-actions/actionlint@e01d1ea33dd6a5ed517d95b4c0c357560ac6f518 # v2.1.1
+
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
+        with:
+          advanced-security: false
+
+  ghalint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: stable
+
+      - name: Install ghalint
+        run: go install github.com/suzuki-shunsuke/ghalint/cmd/ghalint@v1.5.5
+
+      - name: Run ghalint
+        run: ghalint run


### PR DESCRIPTION
## Summary
- Add PR workflow (`.github/workflows/pr.yaml`) that uses `tj-actions/changed-files` to detect changes and conditionally triggers reusable workflows
- Add GitHub Actions check workflow (`.github/workflows/reusable-check-github-actions.yaml`) with actionlint, zizmor, and ghalint
- All actions are pinned by SHA with version comments

## Test plan
- [ ] Open this PR and verify the CI runs successfully
- [ ] Confirm actionlint, zizmor, and ghalint jobs pass