### PR TITLE
ci: add status job to PR workflow for required status check

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,3 +33,21 @@ jobs:
     uses: ./.github/workflows/reusable-check-github-actions.yaml
     permissions:
       contents: read
+
+  status:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      - check-github-actions
+    permissions: {}
+    steps:
+      - name: Check job results
+        env:
+          HAS_FAILURE: ${{ contains(needs.*.result, 'failure') }}
+          HAS_CANCELLED: ${{ contains(needs.*.result, 'cancelled') }}
+        run: |
+          if [[ "$HAS_FAILURE" == "true" || "$HAS_CANCELLED" == "true" ]]; then
+            echo "::error::Some jobs failed or were cancelled"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Add `status` gate job to PR workflow that aggregates all job results
- Enables branch protection with a single required status check (`status`)
- Uses `if: always()` to run even when jobs are skipped, and treats `skipped` as success

## Test plan
- [ ] Verify the `status` job passes when all jobs succeed or are skipped
- [ ] Configure branch protection to require the `status` check