### PR TITLE
ci: add plugins check reusable workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,7 @@ jobs:
     outputs:
       github-actions: ${{ steps.changed-files.outputs.github-actions_any_changed }}
       packages: ${{ steps.changed-files.outputs.packages_any_changed }}
+      plugins: ${{ steps.changed-files.outputs.plugins_any_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -32,6 +33,9 @@ jobs:
               - package.json
               - bun.lock
               - tsconfig.base.json
+            plugins:
+              - plugins/**
+              - .claude-plugin/marketplace.json
 
   check-github-actions:
     needs: changed-files
@@ -47,6 +51,13 @@ jobs:
     permissions:
       contents: read
 
+  check-plugins:
+    needs: changed-files
+    if: needs.changed-files.outputs.plugins == 'true'
+    uses: ./.github/workflows/reusable-check-plugins.yaml
+    permissions:
+      contents: read
+
   status:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -54,6 +65,7 @@ jobs:
     needs:
       - check-github-actions
       - check-packages
+      - check-plugins
     permissions: {}
     steps:
       - name: Check job results

--- a/.github/workflows/reusable-check-plugins.yaml
+++ b/.github/workflows/reusable-check-plugins.yaml
@@ -1,0 +1,28 @@
+name: Check Plugins
+
+on:
+  workflow_call:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check format
+        run: bun run format:check
+
+      - name: Validate plugins
+        run: bunx @anthropic-ai/claude-code plugin validate .


### PR DESCRIPTION
## Summary
- Add `reusable-check-plugins.yaml` with format check and `claude plugin validate` validation
- Update `pr.yaml` to detect `plugins/**` and `.claude-plugin/marketplace.json` changes and trigger the new workflow
- Add `check-plugins` to the `status` gate job

## Test plan
- [ ] Verify CI triggers when plugin files are changed
- [ ] Verify `claude plugin validate` and format check pass
- [ ] Verify CI is skipped when only non-plugin files are changed