### PR TITLE
feat(claude-tools): add gh list-sub-issues CLI command

### DIFF
--- a/.changeset/add-list-sub-issues-command.md
+++ b/.changeset/add-list-sub-issues-command.md
@@ -1,0 +1,5 @@
+---
+"@nownabe/claude-tools": minor
+---
+
+Add `gh list-sub-issues` CLI command for listing sub-issues of a GitHub issue

--- a/packages/claude-tools/src/commands/gh/index.ts
+++ b/packages/claude-tools/src/commands/gh/index.ts
@@ -1,3 +1,4 @@
 export const commands: Record<string, () => Promise<void>> = {
   "add-sub-issue": () => import("./add-sub-issue").then((m) => m.main()),
+  "list-sub-issues": () => import("./list-sub-issues").then((m) => m.main()),
 };

--- a/packages/claude-tools/src/commands/gh/list-sub-issues.test.ts
+++ b/packages/claude-tools/src/commands/gh/list-sub-issues.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, mock } from "bun:test";
+import { listSubIssues } from "./list-sub-issues";
+
+function createMockRunner(responses: { stdout: string; stderr: string; exitCode: number }[]) {
+  let callIndex = 0;
+  const calls: string[][] = [];
+  const fn = mock(async (args: string[]) => {
+    calls.push(args);
+    const response = responses[callIndex];
+    callIndex++;
+    return response;
+  });
+  return { fn, calls };
+}
+
+describe("listSubIssues", () => {
+  it("should call gh api with correct endpoint and output result", async () => {
+    const subIssuesJson = JSON.stringify([
+      { id: 1, number: 10, title: "Sub-issue 1" },
+      { id: 2, number: 11, title: "Sub-issue 2" },
+    ]);
+    const { fn, calls } = createMockRunner([{ stdout: subIssuesJson, stderr: "", exitCode: 0 }]);
+
+    await listSubIssues({ owner: "myorg", repo: "myrepo", issueNumber: 5 }, fn);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["api", "repos/myorg/myrepo/issues/5/sub_issues"]);
+  });
+
+  it("should exit with error when API call fails", async () => {
+    const { fn } = createMockRunner([{ stdout: "", stderr: "Not Found", exitCode: 1 }]);
+
+    const mockExit = mock(() => {
+      throw new Error("process.exit");
+    });
+    const originalExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    try {
+      await listSubIssues({ owner: "myorg", repo: "myrepo", issueNumber: 999 }, fn);
+    } catch {
+      // expected
+    }
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    process.exit = originalExit;
+  });
+});

--- a/packages/claude-tools/src/commands/gh/list-sub-issues.ts
+++ b/packages/claude-tools/src/commands/gh/list-sub-issues.ts
@@ -1,0 +1,61 @@
+export interface ListSubIssuesOptions {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+}
+
+interface RunCommandFn {
+  (args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }>;
+}
+
+async function runGh(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(["gh", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+export async function listSubIssues(
+  options: ListSubIssuesOptions,
+  runCommand: RunCommandFn = runGh,
+): Promise<void> {
+  const { owner, repo, issueNumber } = options;
+
+  const result = await runCommand([
+    "api",
+    `repos/${owner}/${repo}/issues/${issueNumber}/sub_issues`,
+  ]);
+
+  if (result.exitCode !== 0) {
+    console.error(`Failed to list sub-issues for #${issueNumber}: ${result.stderr}`);
+    process.exit(1);
+  }
+
+  console.log(result.stdout);
+}
+
+export async function main(): Promise<void> {
+  const [owner, repo, issueStr] = process.argv.slice(4);
+
+  if (!owner || !repo || !issueStr) {
+    console.error("Usage: claude-tools gh list-sub-issues <owner> <repo> <issue_number>");
+    process.exit(1);
+  }
+
+  const issueNumber = Number(issueStr);
+
+  if (Number.isNaN(issueNumber)) {
+    console.error("Issue number must be a valid integer");
+    process.exit(1);
+  }
+
+  await listSubIssues({ owner, repo, issueNumber });
+}


### PR DESCRIPTION
## Summary

- Add `gh list-sub-issues` CLI command to `@nownabe/claude-tools` that retrieves sub-issues for a given GitHub issue
- Usage: `bunx @nownabe/claude-tools gh list-sub-issues <owner> <repo> <issue_number>`
- Follows the same implementation pattern as the existing `gh add-sub-issue` command

## Test plan

- [x] Unit tests pass (`bun run check`)
- [ ] Manual test: `bunx @nownabe/claude-tools gh list-sub-issues nownabe claude <issue_number>`