### PR TITLE
fix: use GitHub App token in release workflow to trigger PR checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,8 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Replace `GITHUB_TOKEN` with a GitHub App token in the release workflow so that changeset PRs trigger the Pull Request workflow and pass the required `status` check.

## Notes
- GitHub App ID: `vars.GH_APP_RELEASER_ID`
- GitHub App Private Key: `secrets.GH_APP_RELEASER_PKEY`
- The GitHub App needs `contents: write` and `pull_requests: write` permissions on this repository.
- After merging, close and re-create PR #29 (or push a new commit) to trigger the status check.