### PR TITLE
fix: add id-token permission for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission to the release workflow, which is required for npm trusted publishing (OIDC)
- The permission was missing when job permissions were minimized in dcd6951

## Test plan
- [ ] Merge and verify the release workflow succeeds