### PR TITLE
fix: add repository field to package.json for provenance verification

### DIFF
--- a/packages/claude-hooks/package.json
+++ b/packages/claude-hooks/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@nownabe/claude-hooks",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nownabe/claude",
+    "directory": "packages/claude-hooks"
+  },
   "bin": "./src/cli.ts",
   "files": [
     "src"

--- a/packages/claude-tools/package.json
+++ b/packages/claude-tools/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@nownabe/claude-tools",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nownabe/claude",
+    "directory": "packages/claude-tools"
+  },
   "bin": "./src/cli.ts",
   "files": [
     "src"


### PR DESCRIPTION
## Summary
- Add `repository` field to both packages' `package.json`
- npm provenance verification requires `repository.url` to match the GitHub repository URL from the OIDC token
- Error was: `"repository.url" is "", expected to match "https://github.com/nownabe/claude" from provenance`

## Test plan
- [ ] Merge and verify the release workflow publishes `@nownabe/claude-tools` successfully