### PR TITLE
feat(claude-hooks): unify config files into nownabe-claude-hooks.json

### DIFF
--- a/.changeset/unify-config-files.md
+++ b/.changeset/unify-config-files.md
@@ -1,0 +1,5 @@
+---
+"@nownabe/claude-hooks": minor
+---
+
+Unify config files into a single `nownabe-claude-hooks.json` with deep merge strategy

--- a/packages/claude-hooks/README.md
+++ b/packages/claude-hooks/README.md
@@ -8,6 +8,40 @@ A collection of [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-co
 npm install -g @nownabe/claude-hooks
 ```
 
+## Configuration
+
+All hooks share a single config file: `.claude/nownabe-claude-hooks.json` (or `.claude/nownabe-claude-hooks.local.json` for machine-local overrides).
+
+```json
+{
+  "preBash": {
+    "forbiddenPatterns": [
+      {
+        "pattern": "\\bgit\\s+-C\\b",
+        "reason": "git -C is not allowed",
+        "suggestion": "Run git commands from the working directory directly"
+      }
+    ]
+  },
+  "notification": {
+    "sounds": {
+      "permission_prompt": "C:\\Windows\\Media\\Windows Notify System Generic.wav",
+      "*": "C:\\Windows\\Media\\tada.wav"
+    }
+  }
+}
+```
+
+Config files are loaded hierarchically from the current working directory up to `$HOME`. Files are deep merged — objects are recursively merged (child keys override parent keys), while arrays and primitives are replaced entirely by the child value.
+
+File priority (highest first, per directory from CWD to HOME):
+
+1. `CWD/.claude/nownabe-claude-hooks.local.json`
+2. `CWD/.claude/nownabe-claude-hooks.json`
+3. `<parent>/.claude/nownabe-claude-hooks.local.json`
+4. `<parent>/.claude/nownabe-claude-hooks.json`
+5. ... up to `$HOME`
+
 ## Hooks
 
 ### `pre-bash` — Forbidden Command Patterns
@@ -38,27 +72,23 @@ Add to your `settings.json` (`~/.claude/settings.json`, `.claude/settings.json`,
 
 #### Configuration
 
-Create `.claude/pre-bash.json` in your home directory or any ancestor directory of your project:
+Add a `preBash` section to your `.claude/nownabe-claude-hooks.json`:
 
 ```json
 {
-  "forbiddenPatterns": [
-    {
-      "pattern": "\\bgit\\s+-C\\b",
-      "reason": "git -C is not allowed",
-      "suggestion": "Run git commands from the working directory directly"
-    }
-  ]
+  "preBash": {
+    "forbiddenPatterns": [
+      {
+        "pattern": "\\bgit\\s+-C\\b",
+        "reason": "git -C is not allowed",
+        "suggestion": "Run git commands from the working directory directly"
+      }
+    ]
+  }
 }
 ```
 
-Child directories override parent patterns. To disable a parent pattern:
-
-```json
-{
-  "forbiddenPatterns": [{ "pattern": "\\bgit\\s+-C\\b", "disabled": true }]
-}
-```
+When a child directory defines `forbiddenPatterns`, it replaces the parent's array entirely. To inherit everything, omit the `preBash` section.
 
 ### `notification` — OS-Native Notifications
 
@@ -88,13 +118,15 @@ Add to your `settings.json`:
 
 #### Configuration
 
-Optionally create `.claude/notification.json` to customize notification sounds:
+Add a `notification` section to your `.claude/nownabe-claude-hooks.json`:
 
 ```json
 {
-  "sounds": {
-    "permission_prompt": "C:\\Windows\\Media\\Windows Notify System Generic.wav",
-    "*": "C:\\Windows\\Media\\tada.wav"
+  "notification": {
+    "sounds": {
+      "permission_prompt": "C:\\Windows\\Media\\Windows Notify System Generic.wav",
+      "*": "C:\\Windows\\Media\\tada.wav"
+    }
   }
 }
 ```
@@ -102,7 +134,7 @@ Optionally create `.claude/notification.json` to customize notification sounds:
 - `permission_prompt` — Sound for permission prompts
 - `*` — Default sound for all other notification types (e.g., `stop`, task completion)
 
-Config files are loaded hierarchically from the current working directory up to `$HOME`. Child directories override parent values.
+Sound keys from child directories override parent keys (object merge).
 
 #### Supported Platforms
 

--- a/packages/claude-hooks/src/config.ts
+++ b/packages/claude-hooks/src/config.ts
@@ -1,0 +1,119 @@
+/**
+ * Unified config loader for nownabe-claude-hooks.
+ * Loads and deep-merges config files from CWD up to HOME.
+ */
+
+import { resolve, dirname, join } from "path";
+import { existsSync, readFileSync } from "fs";
+import type { ForbiddenPatternEntry } from "./pre-bash";
+
+// --- Types ---
+
+export interface Config {
+  preBash?: {
+    forbiddenPatterns?: ForbiddenPatternEntry[];
+  };
+  notification?: {
+    sounds?: Record<string, string>;
+  };
+}
+
+// --- Constants ---
+
+const CONFIG_FILENAME = "nownabe-claude-hooks.json";
+const LOCAL_CONFIG_FILENAME = "nownabe-claude-hooks.local.json";
+
+// --- Helpers ---
+
+/**
+ * Collect directories from `startDir` up to (and including) `stopDir`.
+ * Returns paths from startDir (most specific) to stopDir (least specific).
+ */
+export function collectAncestorDirs(startDir: string, stopDir: string): string[] {
+  const start = resolve(startDir);
+  const stop = resolve(stopDir);
+  const dirs: string[] = [];
+  let current = start;
+  for (;;) {
+    dirs.push(current);
+    if (current === stop) break;
+    const parent = dirname(current);
+    if (parent === current) break; // reached filesystem root
+    current = parent;
+  }
+  return dirs;
+}
+
+/**
+ * Recursively deep merge two objects.
+ * - Objects: recursively merged (keys from `override` win)
+ * - Arrays/primitives: replaced entirely by `override`
+ */
+export function deepMerge(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base };
+  for (const key of Object.keys(override)) {
+    const baseVal = base[key];
+    const overrideVal = override[key];
+    if (isPlainObject(baseVal) && isPlainObject(overrideVal)) {
+      result[key] = deepMerge(
+        baseVal as Record<string, unknown>,
+        overrideVal as Record<string, unknown>,
+      );
+    } else {
+      result[key] = overrideVal;
+    }
+  }
+  return result;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Load config files from CWD up to HOME and deep merge them.
+ *
+ * File priority (highest first, per directory from CWD to HOME):
+ * 1. CWD/.claude/nownabe-claude-hooks.local.json
+ * 2. CWD/.claude/nownabe-claude-hooks.json
+ * 3. <parent>/.claude/nownabe-claude-hooks.local.json
+ * 4. <parent>/.claude/nownabe-claude-hooks.json
+ * 5. ... up to HOME
+ *
+ * Merge: Start from the lowest-priority file, deep merge upward.
+ */
+export function loadConfig(cwd: string): Config {
+  const home = process.env.HOME ?? "";
+  if (!home) return {};
+
+  const dirs = collectAncestorDirs(cwd, home);
+
+  // Collect config files in priority order (highest first).
+  // Per directory: local file has higher priority than non-local.
+  const configFiles: string[] = [];
+  for (const dir of dirs) {
+    const claudeDir = join(dir, ".claude");
+    const localPath = join(claudeDir, LOCAL_CONFIG_FILENAME);
+    const normalPath = join(claudeDir, CONFIG_FILENAME);
+    if (existsSync(localPath)) configFiles.push(localPath);
+    if (existsSync(normalPath)) configFiles.push(normalPath);
+  }
+
+  // Merge from lowest priority (last) to highest priority (first).
+  let merged: Record<string, unknown> = {};
+  for (const filePath of configFiles.reverse()) {
+    try {
+      const content = JSON.parse(readFileSync(filePath, "utf-8"));
+      if (isPlainObject(content)) {
+        merged = deepMerge(merged, content);
+      }
+    } catch {
+      // skip malformed files
+    }
+  }
+
+  return merged as Config;
+}

--- a/packages/claude-hooks/tests/config.test.ts
+++ b/packages/claude-hooks/tests/config.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { join } from "path";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { collectAncestorDirs, deepMerge, loadConfig } from "../src/config";
+
+describe("collectAncestorDirs", () => {
+  test("returns single directory when start equals stop", () => {
+    expect(collectAncestorDirs("/home/user", "/home/user")).toEqual(["/home/user"]);
+  });
+
+  test("returns path from start to stop", () => {
+    expect(collectAncestorDirs("/home/user/projects/app", "/home/user")).toEqual([
+      "/home/user/projects/app",
+      "/home/user/projects",
+      "/home/user",
+    ]);
+  });
+
+  test("stops at filesystem root if stop is not an ancestor", () => {
+    const result = collectAncestorDirs("/tmp/a", "/other");
+    expect(result[0]).toBe("/tmp/a");
+    expect(result[result.length - 1]).toBe("/");
+  });
+});
+
+describe("deepMerge", () => {
+  test("merges flat objects", () => {
+    expect(deepMerge({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
+  });
+
+  test("override wins for same key", () => {
+    expect(deepMerge({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+  });
+
+  test("recursively merges nested objects", () => {
+    const base = { nested: { a: 1, b: 2 } };
+    const override = { nested: { b: 3, c: 4 } };
+    expect(deepMerge(base, override)).toEqual({ nested: { a: 1, b: 3, c: 4 } });
+  });
+
+  test("arrays are replaced entirely", () => {
+    const base = { items: [1, 2, 3] };
+    const override = { items: [4, 5] };
+    expect(deepMerge(base, override)).toEqual({ items: [4, 5] });
+  });
+
+  test("primitives are replaced", () => {
+    expect(deepMerge({ a: "foo" }, { a: "bar" })).toEqual({ a: "bar" });
+  });
+
+  test("override object replaces primitive", () => {
+    expect(deepMerge({ a: 1 }, { a: { nested: true } })).toEqual({ a: { nested: true } });
+  });
+
+  test("override primitive replaces object", () => {
+    expect(deepMerge({ a: { nested: true } }, { a: 1 })).toEqual({ a: 1 });
+  });
+
+  test("handles empty objects", () => {
+    expect(deepMerge({}, { a: 1 })).toEqual({ a: 1 });
+    expect(deepMerge({ a: 1 }, {})).toEqual({ a: 1 });
+  });
+
+  test("deeply nested merge", () => {
+    const base = { a: { b: { c: 1, d: 2 } } };
+    const override = { a: { b: { d: 3, e: 4 } } };
+    expect(deepMerge(base, override)).toEqual({ a: { b: { c: 1, d: 3, e: 4 } } });
+  });
+});
+
+describe("loadConfig", () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "config-test-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  function writeConfig(dir: string, config: object, local = false) {
+    const claudeDir = join(dir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    const filename = local ? "nownabe-claude-hooks.local.json" : "nownabe-claude-hooks.json";
+    writeFileSync(join(claudeDir, filename), JSON.stringify(config));
+  }
+
+  test("returns empty config when no config files exist", () => {
+    const cwd = join(tmpDir, "a", "b");
+    mkdirSync(cwd, { recursive: true });
+    expect(loadConfig(cwd)).toEqual({});
+  });
+
+  test("loads config from HOME", () => {
+    writeConfig(tmpDir, {
+      preBash: {
+        forbiddenPatterns: [{ pattern: "\\bfoo\\b", reason: "no foo", suggestion: "use bar" }],
+      },
+    });
+    const config = loadConfig(tmpDir);
+    expect(config.preBash?.forbiddenPatterns).toEqual([
+      { pattern: "\\bfoo\\b", reason: "no foo", suggestion: "use bar" },
+    ]);
+  });
+
+  test("deep merges notification sounds from multiple levels", () => {
+    const projectDir = join(tmpDir, "project");
+    mkdirSync(projectDir, { recursive: true });
+
+    writeConfig(tmpDir, {
+      notification: { sounds: { "*": "parent.wav", stop: "parent-stop.wav" } },
+    });
+    writeConfig(projectDir, {
+      notification: { sounds: { "*": "child.wav" } },
+    });
+
+    const config = loadConfig(projectDir);
+    expect(config.notification?.sounds?.["*"]).toBe("child.wav");
+    expect(config.notification?.sounds?.stop).toBe("parent-stop.wav");
+  });
+
+  test("child array replaces parent array entirely", () => {
+    const projectDir = join(tmpDir, "project");
+    mkdirSync(projectDir, { recursive: true });
+
+    writeConfig(tmpDir, {
+      preBash: {
+        forbiddenPatterns: [
+          { pattern: "\\bfoo\\b", reason: "no foo", suggestion: "use bar" },
+          { pattern: "\\bbaz\\b", reason: "no baz", suggestion: "use qux" },
+        ],
+      },
+    });
+    writeConfig(projectDir, {
+      preBash: {
+        forbiddenPatterns: [
+          { pattern: "\\bonly\\b", reason: "only this", suggestion: "just this" },
+        ],
+      },
+    });
+
+    const config = loadConfig(projectDir);
+    expect(config.preBash?.forbiddenPatterns).toEqual([
+      { pattern: "\\bonly\\b", reason: "only this", suggestion: "just this" },
+    ]);
+  });
+
+  test(".local.json has higher priority than .json in same directory", () => {
+    writeConfig(tmpDir, {
+      notification: { sounds: { "*": "normal.wav" } },
+    });
+    writeConfig(
+      tmpDir,
+      {
+        notification: { sounds: { "*": "local.wav" } },
+      },
+      true,
+    );
+
+    const config = loadConfig(tmpDir);
+    expect(config.notification?.sounds?.["*"]).toBe("local.wav");
+  });
+
+  test(".local.json in child overrides .json in child", () => {
+    const projectDir = join(tmpDir, "project");
+    mkdirSync(projectDir, { recursive: true });
+
+    writeConfig(projectDir, {
+      notification: { sounds: { "*": "normal.wav" } },
+    });
+    writeConfig(
+      projectDir,
+      {
+        notification: { sounds: { "*": "local.wav" } },
+      },
+      true,
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.notification?.sounds?.["*"]).toBe("local.wav");
+  });
+
+  test("child .json overrides parent .local.json", () => {
+    const projectDir = join(tmpDir, "project");
+    mkdirSync(projectDir, { recursive: true });
+
+    writeConfig(
+      tmpDir,
+      {
+        notification: { sounds: { "*": "parent-local.wav" } },
+      },
+      true,
+    );
+    writeConfig(projectDir, {
+      notification: { sounds: { "*": "child.wav" } },
+    });
+
+    const config = loadConfig(projectDir);
+    expect(config.notification?.sounds?.["*"]).toBe("child.wav");
+  });
+
+  test("merges preBash and notification from different levels", () => {
+    const projectDir = join(tmpDir, "project");
+    mkdirSync(projectDir, { recursive: true });
+
+    writeConfig(tmpDir, {
+      preBash: {
+        forbiddenPatterns: [{ pattern: "\\bfoo\\b", reason: "no foo", suggestion: "use bar" }],
+      },
+    });
+    writeConfig(projectDir, {
+      notification: { sounds: { "*": "child.wav" } },
+    });
+
+    const config = loadConfig(projectDir);
+    expect(config.preBash?.forbiddenPatterns).toEqual([
+      { pattern: "\\bfoo\\b", reason: "no foo", suggestion: "use bar" },
+    ]);
+    expect(config.notification?.sounds?.["*"]).toBe("child.wav");
+  });
+
+  test("skips malformed JSON files", () => {
+    const claudeDir = join(tmpDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "nownabe-claude-hooks.json"), "not json");
+
+    expect(loadConfig(tmpDir)).toEqual({});
+  });
+
+  test("returns empty config when HOME is not set", () => {
+    delete process.env.HOME;
+    expect(loadConfig("/some/path")).toEqual({});
+  });
+});

--- a/packages/claude-hooks/tests/notification.test.ts
+++ b/packages/claude-hooks/tests/notification.test.ts
@@ -84,10 +84,13 @@ describe("loadNotificationConfig", () => {
     rmSync(tmpDir, { recursive: true });
   });
 
-  function writeConfig(dir: string, config: object) {
+  function writeConfig(dir: string, notificationConfig: object) {
     const claudeDir = join(dir, ".claude");
     mkdirSync(claudeDir, { recursive: true });
-    writeFileSync(join(claudeDir, "notification.json"), JSON.stringify(config));
+    writeFileSync(
+      join(claudeDir, "nownabe-claude-hooks.json"),
+      JSON.stringify({ notification: notificationConfig }),
+    );
   }
 
   test("returns empty config when no config files exist", () => {
@@ -140,7 +143,7 @@ describe("loadNotificationConfig", () => {
   test("skips malformed JSON files", () => {
     const claudeDir = join(tmpDir, ".claude");
     mkdirSync(claudeDir, { recursive: true });
-    writeFileSync(join(claudeDir, "notification.json"), "not json");
+    writeFileSync(join(claudeDir, "nownabe-claude-hooks.json"), "not json");
 
     expect(loadNotificationConfig(tmpDir)).toEqual({});
   });


### PR DESCRIPTION
## Summary

- Replace separate `pre-bash.json` and `notification.json` config files with a single `nownabe-claude-hooks.json` (+ `.local.json` for machine-local overrides)
- Extract shared `collectAncestorDirs` and add `deepMerge` utility into a new `src/config.ts` module
- Deep merge strategy: objects are recursively merged (child keys override parent), arrays/primitives are replaced entirely by higher-priority values

## Test plan

- [x] All existing tests updated to use new config format
- [x] New `tests/config.test.ts` covers `collectAncestorDirs`, `deepMerge`, and `loadConfig` (file priority, `.local.json` override, deep merge behavior, malformed files, missing HOME)
- [x] `bun run check` passes (lint, typecheck, format, 50 tests)