### PR TITLE
feat(base): add pre-bash hook for command validation

### DIFF
--- a/plugins/base/hooks/hooks.json
+++ b/plugins/base/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bunx @nownabe/claude-hooks pre-bash"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add a `PreToolUse` hook to the base plugin that validates Bash commands using `@nownabe/claude-hooks pre-bash`
- When the base plugin is installed, Bash commands are automatically checked against forbidden patterns defined in `pre-bash.json` config files (from CWD up to HOME)
- Matching commands are denied with a reason and suggestion

## Test plan

- [ ] Load the plugin with `claude --plugin-dir ./plugins/base` and verify the hook appears in `/hooks`
- [ ] Configure a `pre-bash.json` with a forbidden pattern and verify that matching Bash commands are blocked
- [ ] Verify non-matching commands proceed normally
- [ ] Run `/plugin validate .` to validate the plugin structure