### PR TITLE
feat(base): add pre-bash hook for command validation

### DIFF
--- a/.changeset/add-pre-bash-hook.md
+++ b/.changeset/add-pre-bash-hook.md
@@ -1,0 +1,5 @@
+---
+"@nownabe/claude-hooks": minor
+---
+
+Add pre-bash command for validating Bash commands against forbidden patterns


### PR DESCRIPTION
## Summary
- Wire the `@nownabe/claude-hooks pre-bash` command as a PreToolUse hook in the base plugin
- When installed, Bash commands are validated against forbidden patterns defined in config files
- Add changeset for the pre-bash command

## Test plan
- [ ] Verify hooks.json is correctly structured
- [ ] Confirm pre-bash hook validates commands as expected when the plugin is installed