### PR TITLE
chore: enable signed commits for changesets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,7 @@ jobs:
           publish: bun run release
           title: "chore: version packages"
           commit: "chore: version packages"
+          commitMode: "github-api"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
## Summary

- Add `commitMode: "github-api"` to `changesets/action` in the release workflow
- Version bump commits and tags will be GPG-signed by GitHub and attributed to the GitHub App
- No additional key management required since we already use a GitHub App token

## Test plan

- [x] Verified the `commitMode` option is supported by changesets/action v1.7.0
- [ ] Next release will verify commits show as "Verified" in GitHub UI