### PR TITLE
feat(base): add notification hooks using claude-hooks

### DIFF
--- a/plugins/base/hooks/hooks.json
+++ b/plugins/base/hooks/hooks.json
@@ -10,6 +10,30 @@
           }
         ]
       }
+    ],
+    "Notification": [
+      {
+        "matcher": "idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bunx @nownabe/claude-hooks notification",
+            "async": true,
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bunx @nownabe/claude-hooks notification",
+            "async": true,
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add Notification hooks to the base plugin for `idle_prompt` and `permission_prompt` events
- Uses the existing `@nownabe/claude-hooks notification` command for OS-native notifications
- Notifications run asynchronously with a 30-second timeout

## Test plan
- [ ] Enable the base plugin and verify notifications fire on idle prompt
- [ ] Verify notifications fire on permission prompt