### PR TITLE
feat(claude-tools): add resolve-tag-sha command

### DIFF
--- a/.changeset/resolve-tag-sha.md
+++ b/.changeset/resolve-tag-sha.md
@@ -1,0 +1,5 @@
+---
+"@nownabe/claude-tools": minor
+---
+
+Add `resolve-tag-sha` command to resolve GitHub tags to commit SHAs

--- a/packages/claude-tools/src/commands/gh/index.ts
+++ b/packages/claude-tools/src/commands/gh/index.ts
@@ -1,4 +1,5 @@
 export const commands: Record<string, () => Promise<void>> = {
   "add-sub-issues": () => import("./add-sub-issues").then((m) => m.main()),
   "list-sub-issues": () => import("./list-sub-issues").then((m) => m.main()),
+  "resolve-tag-sha": () => import("./resolve-tag-sha").then((m) => m.main()),
 };

--- a/packages/claude-tools/src/commands/gh/resolve-tag-sha.test.ts
+++ b/packages/claude-tools/src/commands/gh/resolve-tag-sha.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, mock } from "bun:test";
+import { resolveTagSha } from "./resolve-tag-sha";
+
+function createMockRunner(responses: { stdout: string; stderr: string; exitCode: number }[]) {
+  let callIndex = 0;
+  const calls: string[][] = [];
+  const fn = mock(async (args: string[]) => {
+    calls.push(args);
+    const response = responses[callIndex];
+    callIndex++;
+    return response;
+  });
+  return { fn, calls };
+}
+
+describe("resolveTagSha", () => {
+  it("should resolve a lightweight tag directly", async () => {
+    const { fn, calls } = createMockRunner([
+      {
+        stdout: JSON.stringify({ type: "commit", sha: "abc123def456" }),
+        stderr: "",
+        exitCode: 0,
+      },
+    ]);
+
+    const sha = await resolveTagSha({ repo: "actions/setup-node", tag: "v4.4.0" }, fn);
+
+    expect(sha).toBe("abc123def456");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual([
+      "api",
+      "repos/actions/setup-node/git/ref/tags/v4.4.0",
+      "--jq",
+      ".object",
+    ]);
+  });
+
+  it("should dereference an annotated tag to get the commit SHA", async () => {
+    const { fn, calls } = createMockRunner([
+      {
+        stdout: JSON.stringify({ type: "tag", sha: "tag-object-sha" }),
+        stderr: "",
+        exitCode: 0,
+      },
+      {
+        stdout: "commit-sha-from-annotated-tag",
+        stderr: "",
+        exitCode: 0,
+      },
+    ]);
+
+    const sha = await resolveTagSha({ repo: "dorny/paths-filter", tag: "v3.0.2" }, fn);
+
+    expect(sha).toBe("commit-sha-from-annotated-tag");
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual([
+      "api",
+      "repos/dorny/paths-filter/git/ref/tags/v3.0.2",
+      "--jq",
+      ".object",
+    ]);
+    expect(calls[1]).toEqual([
+      "api",
+      "repos/dorny/paths-filter/git/tags/tag-object-sha",
+      "--jq",
+      ".object.sha",
+    ]);
+  });
+
+  it("should exit with error when the ref API call fails", async () => {
+    const { fn } = createMockRunner([{ stdout: "", stderr: "Not Found", exitCode: 1 }]);
+
+    const mockExit = mock(() => {
+      throw new Error("process.exit");
+    });
+    const originalExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    try {
+      await resolveTagSha({ repo: "actions/setup-node", tag: "nonexistent" }, fn);
+    } catch {
+      // expected
+    }
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    process.exit = originalExit;
+  });
+
+  it("should exit with error when dereferencing an annotated tag fails", async () => {
+    const { fn } = createMockRunner([
+      {
+        stdout: JSON.stringify({ type: "tag", sha: "tag-object-sha" }),
+        stderr: "",
+        exitCode: 0,
+      },
+      { stdout: "", stderr: "Internal Server Error", exitCode: 1 },
+    ]);
+
+    const mockExit = mock(() => {
+      throw new Error("process.exit");
+    });
+    const originalExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    try {
+      await resolveTagSha({ repo: "dorny/paths-filter", tag: "v3.0.2" }, fn);
+    } catch {
+      // expected
+    }
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    process.exit = originalExit;
+  });
+
+  it("should exit with error for unexpected object type", async () => {
+    const { fn } = createMockRunner([
+      {
+        stdout: JSON.stringify({ type: "blob", sha: "some-sha" }),
+        stderr: "",
+        exitCode: 0,
+      },
+    ]);
+
+    const mockExit = mock(() => {
+      throw new Error("process.exit");
+    });
+    const originalExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    try {
+      await resolveTagSha({ repo: "some/repo", tag: "v1.0.0" }, fn);
+    } catch {
+      // expected
+    }
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    process.exit = originalExit;
+  });
+});

--- a/packages/claude-tools/src/commands/gh/resolve-tag-sha.ts
+++ b/packages/claude-tools/src/commands/gh/resolve-tag-sha.ts
@@ -1,0 +1,66 @@
+import { type RunCommandFn, runGh } from "./repo";
+
+export interface ResolveTagShaOptions {
+  repo: string;
+  tag: string;
+}
+
+export async function resolveTagSha(
+  options: ResolveTagShaOptions,
+  runCommand: RunCommandFn = runGh,
+): Promise<string> {
+  const { repo, tag } = options;
+
+  const refResult = await runCommand([
+    "api",
+    `repos/${repo}/git/ref/tags/${tag}`,
+    "--jq",
+    ".object",
+  ]);
+
+  if (refResult.exitCode !== 0) {
+    console.error(`Failed to resolve tag "${tag}" in ${repo}: ${refResult.stderr}`);
+    process.exit(1);
+  }
+
+  const refObject: { type: string; sha: string } = JSON.parse(refResult.stdout);
+
+  if (refObject.type === "commit") {
+    return refObject.sha;
+  }
+
+  if (refObject.type === "tag") {
+    const tagResult = await runCommand([
+      "api",
+      `repos/${repo}/git/tags/${refObject.sha}`,
+      "--jq",
+      ".object.sha",
+    ]);
+
+    if (tagResult.exitCode !== 0) {
+      console.error(`Failed to dereference annotated tag "${tag}" in ${repo}: ${tagResult.stderr}`);
+      process.exit(1);
+    }
+
+    return tagResult.stdout;
+  }
+
+  console.error(`Unexpected object type "${refObject.type}" for tag "${tag}" in ${repo}`);
+  process.exit(1);
+}
+
+export async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  // args[0] = group ("gh"), args[1] = command ("resolve-tag-sha"), rest = positional args
+  const remaining = args.slice(2);
+
+  if (remaining.length < 2) {
+    console.error("Usage: claude-tools gh resolve-tag-sha <owner/repo> <tag>");
+    process.exit(1);
+  }
+
+  const [repo, tag] = remaining;
+
+  const sha = await resolveTagSha({ repo, tag });
+  console.log(`${repo}@${sha} # ${tag}`);
+}


### PR DESCRIPTION
## Summary

- Add `gh resolve-tag-sha` command to `@nownabe/claude-tools` that resolves GitHub repository tags to their commit SHAs
- Handles both lightweight tags (direct commit reference) and annotated tags (dereferences the tag object)
- Useful for pinning GitHub Actions to commit SHAs instead of tags for improved security

### Usage

```
claude-tools gh resolve-tag-sha <owner/repo> <tag>
```

### Example

```
$ claude-tools gh resolve-tag-sha actions/setup-node v4.4.0
actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
```

Closes #17

## Test plan

- [x] Unit tests for lightweight tag resolution
- [x] Unit tests for annotated tag dereferencing
- [x] Unit tests for error cases (not found, dereference failure, unexpected type)
- [ ] Manual test with a real lightweight tag
- [ ] Manual test with a real annotated tag (e.g. `dorny/paths-filter v3.0.2`)