### PR TITLE
feat(claude-tools): add gh get-release command

### DIFF
--- a/.changeset/get-release.md
+++ b/.changeset/get-release.md
@@ -1,0 +1,5 @@
+---
+"@nownabe/claude-tools": minor
+---
+
+Add `gh get-release` command to fetch GitHub release information

--- a/packages/claude-tools/README.md
+++ b/packages/claude-tools/README.md
@@ -25,6 +25,22 @@ claude-tools gh add-sub-issues 1 2 3 4
 claude-tools gh add-sub-issues 1 2 3 --repo myorg/myrepo
 ```
 
+### `gh get-release`
+
+Get release information from a GitHub repository. Fetches the latest release by default, or a specific release by tag. Supports `--jq` for filtering output.
+
+```bash
+claude-tools gh get-release [--tag <tag>] [--jq <expression>] [--repo <owner/repo>]
+```
+
+**Example:**
+
+```bash
+claude-tools gh get-release
+claude-tools gh get-release --jq '.tag_name'
+claude-tools gh get-release --tag v1.0.0 --jq '.body' --repo myorg/myrepo
+```
+
 ### `gh list-sub-issues`
 
 List sub-issues of a GitHub issue.

--- a/packages/claude-tools/src/commands/gh/get-release.test.ts
+++ b/packages/claude-tools/src/commands/gh/get-release.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, mock } from "bun:test";
+import { getRelease } from "./get-release";
+
+function createMockRunner(responses: { stdout: string; stderr: string; exitCode: number }[]) {
+  let callIndex = 0;
+  const calls: string[][] = [];
+  const fn = mock(async (args: string[]) => {
+    calls.push(args);
+    const response = responses[callIndex];
+    callIndex++;
+    return response;
+  });
+  return { fn, calls };
+}
+
+describe("getRelease", () => {
+  it("should get the latest release with default jq", async () => {
+    const { fn, calls } = createMockRunner([
+      {
+        stdout: JSON.stringify({ tag_name: "v1.0.0", name: "Release 1.0.0" }),
+        stderr: "",
+        exitCode: 0,
+      },
+    ]);
+
+    const result = await getRelease({ repo: "owner/repo" }, fn);
+
+    expect(result).toBe(JSON.stringify({ tag_name: "v1.0.0", name: "Release 1.0.0" }));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["api", "repos/owner/repo/releases/latest", "--jq", "."]);
+  });
+
+  it("should get the latest release with custom jq", async () => {
+    const { fn, calls } = createMockRunner([
+      {
+        stdout: "v1.0.0",
+        stderr: "",
+        exitCode: 0,
+      },
+    ]);
+
+    const result = await getRelease({ repo: "owner/repo", jq: ".tag_name" }, fn);
+
+    expect(result).toBe("v1.0.0");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["api", "repos/owner/repo/releases/latest", "--jq", ".tag_name"]);
+  });
+
+  it("should get a release by tag", async () => {
+    const { fn, calls } = createMockRunner([
+      {
+        stdout: JSON.stringify({ tag_name: "v2.0.0", body: "Release notes" }),
+        stderr: "",
+        exitCode: 0,
+      },
+    ]);
+
+    const result = await getRelease({ repo: "myorg/myrepo", tag: "v2.0.0" }, fn);
+
+    expect(result).toBe(JSON.stringify({ tag_name: "v2.0.0", body: "Release notes" }));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["api", "repos/myorg/myrepo/releases/tags/v2.0.0", "--jq", "."]);
+  });
+
+  it("should exit with error when the API call fails", async () => {
+    const { fn } = createMockRunner([{ stdout: "", stderr: "Not Found", exitCode: 1 }]);
+
+    const mockExit = mock(() => {
+      throw new Error("process.exit");
+    });
+    const originalExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    try {
+      await getRelease({ repo: "owner/repo" }, fn);
+    } catch {
+      // expected
+    }
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    process.exit = originalExit;
+  });
+});

--- a/packages/claude-tools/src/commands/gh/get-release.ts
+++ b/packages/claude-tools/src/commands/gh/get-release.ts
@@ -1,0 +1,68 @@
+import { type RunCommandFn, runGh, resolveRepo, parseRepoFlag } from "./repo";
+
+export interface GetReleaseOptions {
+  repo: string;
+  tag?: string;
+  jq?: string;
+}
+
+export async function getRelease(
+  options: GetReleaseOptions,
+  runCommand: RunCommandFn = runGh,
+): Promise<string> {
+  const { repo, tag, jq = "." } = options;
+
+  const endpoint = tag ? `repos/${repo}/releases/tags/${tag}` : `repos/${repo}/releases/latest`;
+
+  const result = await runCommand(["api", endpoint, "--jq", jq]);
+
+  if (result.exitCode !== 0) {
+    const target = tag ? `tag "${tag}"` : "latest release";
+    console.error(`Failed to get ${target} for ${repo}: ${result.stderr}`);
+    process.exit(1);
+  }
+
+  return result.stdout;
+}
+
+export async function main(): Promise<void> {
+  const {
+    remaining: allArgs,
+    owner: flagOwner,
+    repo: flagRepo,
+  } = parseRepoFlag(process.argv.slice(2));
+  // allArgs[0] = group ("gh"), allArgs[1] = command ("get-release"), rest = flags
+  const remaining = allArgs.slice(2);
+
+  let tag: string | undefined;
+  let jq: string | undefined;
+
+  for (let i = 0; i < remaining.length; i++) {
+    if (remaining[i] === "--tag") {
+      tag = remaining[i + 1];
+      if (!tag) {
+        console.error("--tag requires a value");
+        process.exit(1);
+      }
+      i++;
+    } else if (remaining[i] === "--jq") {
+      jq = remaining[i + 1];
+      if (!jq) {
+        console.error("--jq requires a value");
+        process.exit(1);
+      }
+      i++;
+    }
+  }
+
+  let repo: string;
+  if (flagOwner && flagRepo) {
+    repo = `${flagOwner}/${flagRepo}`;
+  } else {
+    const resolved = await resolveRepo();
+    repo = `${resolved.owner}/${resolved.repo}`;
+  }
+
+  const output = await getRelease({ repo, tag, jq });
+  console.log(output);
+}

--- a/packages/claude-tools/src/commands/gh/index.ts
+++ b/packages/claude-tools/src/commands/gh/index.ts
@@ -1,5 +1,6 @@
 export const commands: Record<string, () => Promise<void>> = {
   "add-sub-issues": () => import("./add-sub-issues").then((m) => m.main()),
+  "get-release": () => import("./get-release").then((m) => m.main()),
   "list-sub-issues": () => import("./list-sub-issues").then((m) => m.main()),
   "resolve-tag-sha": () => import("./resolve-tag-sha").then((m) => m.main()),
 };


### PR DESCRIPTION
## Summary

- Add `gh get-release` command to fetch GitHub release information
- Supports fetching the latest release (default) or a specific release by `--tag`
- Supports `--jq` for filtering output (defaults to `.`)
- Supports `--repo` flag for specifying repository (auto-detects from cwd if omitted)

## Test plan

- [x] Unit tests for latest release with default jq
- [x] Unit tests for latest release with custom jq
- [x] Unit tests for tag-specific release
- [x] Unit tests for API failure case
- [x] `bun run check` passes (lint, typecheck, format, tests)