### PR TITLE
docs: move Adding a Plugin section to docs/dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,29 +54,6 @@ npm install -g @nownabe/claude-hooks
 
 See [packages/claude-hooks/README.md](packages/claude-hooks/README.md) for details.
 
-## Adding a Plugin
-
-1. Create a plugin directory under `plugins/`:
-
-```
-plugins/my-plugin/
-├── .claude-plugin/
-│   └── plugin.json
-└── skills/
-    └── my-skill/
-        └── SKILL.md
-```
-
-2. Add an entry to `.claude-plugin/marketplace.json`:
-
-```json
-{
-  "name": "my-plugin",
-  "source": "./plugins/my-plugin",
-  "description": "Description of the plugin"
-}
-```
-
 ## License
 
 Apache-2.0

--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -1,0 +1,26 @@
+# Plugins
+
+## Adding a Plugin
+
+1. Create a plugin directory under `plugins/`:
+
+```
+plugins/my-plugin/
+├── .claude-plugin/
+│   └── plugin.json
+└── skills/
+    └── my-skill/
+        └── SKILL.md
+```
+
+2. Add an entry to `.claude-plugin/marketplace.json`:
+
+```json
+{
+  "name": "my-plugin",
+  "source": "./plugins/my-plugin",
+  "description": "Description of the plugin"
+}
+```
+
+3. Validate with `/plugin validate .` and ensure validation passes without errors before committing.


### PR DESCRIPTION
## Summary

- Move "Adding a Plugin" section from root `README.md` to `docs/dev/adding-a-plugin.md`
- Add validation step (`/plugin validate .`) to the guide

## Test plan

- [ ] Verify root README no longer has the Adding a Plugin section
- [ ] Verify `docs/dev/adding-a-plugin.md` has the complete content