### PR TITLE
docs: replace npx with bunx in hook setup examples

### DIFF
--- a/docs/claude-hooks/notification.md
+++ b/docs/claude-hooks/notification.md
@@ -15,7 +15,7 @@ Add to your `settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "npx @nownabe/claude-hooks notification"
+            "command": "bunx @nownabe/claude-hooks notification"
           }
         ]
       }

--- a/docs/claude-hooks/pre-bash.md
+++ b/docs/claude-hooks/pre-bash.md
@@ -15,7 +15,7 @@ Add to your `settings.json` (`~/.claude/settings.json`, `.claude/settings.json`,
         "hooks": [
           {
             "type": "command",
-            "command": "npx @nownabe/claude-hooks pre-bash"
+            "command": "bunx @nownabe/claude-hooks pre-bash"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Replace `npx` with `bunx` in setup examples for `pre-bash` and `notification` hooks

## Test plan

- [ ] Verify no remaining `npx` references in `docs/claude-hooks/`