### PR TITLE
docs: add documentation guidelines reference to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ plugins/
 - **Commit messages**: Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`, `chore:`)
 - **Branching**: Create a feature branch from `main` for each change, then open a pull request
 - **Language**: Write all user-facing content (README, PR descriptions, etc.) in English
+- **Documentation**: Follow the guidelines in [`docs/dev/documentation.md`](docs/dev/documentation.md)
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- Add a Documentation convention entry in CLAUDE.md linking to `docs/dev/documentation.md`

## Test plan

- [ ] Verify the link resolves correctly