### PR TITLE
docs: remove npm install sections from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ Browse and install plugins:
 
 ## Tools
 
-Install:
-
 ```bash
-npm install -g @nownabe/claude-tools
+bunx @nownabe/claude-tools <command>
 ```
 
 | Command              | Description                                      |
@@ -41,10 +39,8 @@ See [packages/claude-tools/README.md](packages/claude-tools/README.md) for detai
 
 ## Hooks
 
-Install:
-
 ```bash
-npm install -g @nownabe/claude-hooks
+bunx @nownabe/claude-hooks <hook>
 ```
 
 | Hook           | Description                               |

--- a/packages/claude-hooks/README.md
+++ b/packages/claude-hooks/README.md
@@ -2,10 +2,10 @@
 
 A collection of [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) for enhanced workflow automation.
 
-## Installation
+## Usage
 
 ```bash
-npm install -g @nownabe/claude-hooks
+bunx @nownabe/claude-hooks <hook>
 ```
 
 ## Configuration

--- a/packages/claude-tools/README.md
+++ b/packages/claude-tools/README.md
@@ -2,10 +2,10 @@
 
 A collection of CLI tools for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) workflows. Provides GitHub-related utilities via the `gh` command group.
 
-## Installation
+## Usage
 
 ```bash
-npm install -g @nownabe/claude-tools
+bunx @nownabe/claude-tools <command>
 ```
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

- Remove `npm install -g` sections from root README, claude-tools README, and claude-hooks README
- Packages are used via `bunx`, so global installation is unnecessary

## Test plan

- [ ] Verify no remaining `npm` references in READMEs