### PR TITLE
docs(claude-tools): fix prerequisites section

### DIFF
--- a/packages/claude-tools/README.md
+++ b/packages/claude-tools/README.md
@@ -11,7 +11,6 @@ bunx @nownabe/claude-tools <command>
 ## Prerequisites
 
 - [GitHub CLI (`gh`)](https://cli.github.com/) must be installed and authenticated
-- For `add-sub-issues` and `list-sub-issues`, the `--repo` flag is optional — if omitted, the repository is detected from the current working directory
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- Remove `--repo` flag usage note from Prerequisites — it's not a prerequisite but a command option

## Test plan

- [ ] Verify Prerequisites only contains actual prerequisites