### PR TITLE
chore: unify changeset descriptions

### DIFF
--- a/.changeset/get-actions-run.md
+++ b/.changeset/get-actions-run.md
@@ -2,4 +2,4 @@
 "@nownabe/claude-tools": minor
 ---
 
-Add `get-actions-run` command to retrieve GitHub Actions workflow run information
+Add `gh get-actions-run` command to retrieve GitHub Actions workflow run information

--- a/.changeset/get-release.md
+++ b/.changeset/get-release.md
@@ -2,4 +2,4 @@
 "@nownabe/claude-tools": minor
 ---
 
-Add `gh get-release` command to fetch GitHub release information
+Add `gh get-release` command to fetch release information from a GitHub repository

--- a/.changeset/resolve-tag-sha.md
+++ b/.changeset/resolve-tag-sha.md
@@ -2,4 +2,4 @@
 "@nownabe/claude-tools": minor
 ---
 
-Add `resolve-tag-sha` command to resolve GitHub tags to commit SHAs
+Add `gh resolve-tag-sha` command to resolve a GitHub tag to its commit SHA


### PR DESCRIPTION
## Summary

- Add `gh` prefix to `resolve-tag-sha` and `get-actions-run` changeset descriptions
- Align description style across all changesets: `Add `gh <command>` command to <description>`

## Test plan

- [ ] Verify all changeset descriptions follow the same format