### PR TITLE
feat(claude-tools): add gh get-job-logs command

### DIFF
--- a/.changeset/add-get-job-logs.md
+++ b/.changeset/add-get-job-logs.md
@@ -1,0 +1,5 @@
+---
+"@nownabe/claude-tools": minor
+---
+
+Add `gh get-job-logs` command to get logs from a GitHub Actions job

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ bunx @nownabe/claude-tools <command>
 | -------------------- | ------------------------------------------------ |
 | `gh add-sub-issues`  | Add sub-issues to a parent GitHub issue          |
 | `gh get-actions-run` | Get GitHub Actions workflow run information      |
+| `gh get-job-logs`    | Get logs from a GitHub Actions job               |
 | `gh get-release`     | Get release information from a GitHub repository |
 | `gh list-run-jobs`   | List jobs from a GitHub Actions workflow run     |
 | `gh list-sub-issues` | List sub-issues of a GitHub issue                |

--- a/docs/claude-tools/gh/get-job-logs.md
+++ b/docs/claude-tools/gh/get-job-logs.md
@@ -1,0 +1,30 @@
+# `gh get-job-logs`
+
+Get logs from a GitHub Actions job.
+
+## Usage
+
+```bash
+claude-tools gh get-job-logs <job_id> [--repo <owner/repo>] [--no-strip-timestamps]
+```
+
+## Arguments
+
+| Argument                | Required | Description                                                                |
+| ----------------------- | -------- | -------------------------------------------------------------------------- |
+| `job_id`                | Yes      | The job ID to retrieve logs for                                            |
+| `--repo <owner/repo>`   | No       | Target repository. If omitted, detected from the current working directory |
+| `--no-strip-timestamps` | No       | Keep timestamps in the output (timestamps are stripped by default)         |
+
+## Examples
+
+```bash
+# Get job logs with timestamps stripped (default)
+claude-tools gh get-job-logs 66031738181
+
+# Get job logs from a specific repository
+claude-tools gh get-job-logs 66031738181 --repo myorg/myrepo
+
+# Get job logs with timestamps preserved
+claude-tools gh get-job-logs 66031738181 --no-strip-timestamps
+```

--- a/packages/claude-tools/README.md
+++ b/packages/claude-tools/README.md
@@ -18,6 +18,7 @@ bunx @nownabe/claude-tools <command>
 | --------------------------------------------------------------------- | ------------------------------------------------ |
 | [`gh add-sub-issues`](../../docs/claude-tools/gh/add-sub-issues.md)   | Add sub-issues to a parent GitHub issue          |
 | [`gh get-actions-run`](../../docs/claude-tools/gh/get-actions-run.md) | Get GitHub Actions workflow run information      |
+| [`gh get-job-logs`](../../docs/claude-tools/gh/get-job-logs.md)       | Get logs from a GitHub Actions job               |
 | [`gh get-release`](../../docs/claude-tools/gh/get-release.md)         | Get release information from a GitHub repository |
 | [`gh list-run-jobs`](../../docs/claude-tools/gh/list-run-jobs.md)     | List jobs from a GitHub Actions workflow run     |
 | [`gh list-sub-issues`](../../docs/claude-tools/gh/list-sub-issues.md) | List sub-issues of a GitHub issue                |

--- a/packages/claude-tools/src/commands/gh/get-job-logs.test.ts
+++ b/packages/claude-tools/src/commands/gh/get-job-logs.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, mock } from "bun:test";
+import { getJobLogs } from "./get-job-logs";
+
+function createMockRunner(responses: { stdout: string; stderr: string; exitCode: number }[]) {
+  let callIndex = 0;
+  const calls: string[][] = [];
+  const fn = mock(async (args: string[]) => {
+    calls.push(args);
+    const response = responses[callIndex];
+    callIndex++;
+    return response;
+  });
+  return { fn, calls };
+}
+
+describe("getJobLogs", () => {
+  it("should call gh api with correct endpoint", async () => {
+    const logs = "Some log output";
+    const { fn, calls } = createMockRunner([{ stdout: logs, stderr: "", exitCode: 0 }]);
+
+    await getJobLogs({ owner: "myorg", repo: "myrepo", jobId: "12345" }, fn);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["api", "repos/myorg/myrepo/actions/jobs/12345/logs"]);
+  });
+
+  it("should strip timestamps by default", async () => {
+    const logs = "2025-03-06T10:30:45.1234567Z Step 1\n2025-03-06T10:30:46.9876543Z Step 2\n";
+    const { fn } = createMockRunner([{ stdout: logs, stderr: "", exitCode: 0 }]);
+
+    const logSpy = mock(() => {});
+    const originalLog = console.log;
+    console.log = logSpy;
+
+    await getJobLogs({ owner: "myorg", repo: "myrepo", jobId: "12345" }, fn);
+
+    console.log = originalLog;
+    expect(logSpy).toHaveBeenCalledWith("Step 1\nStep 2\n");
+  });
+
+  it("should preserve timestamps when stripTimestamps is false", async () => {
+    const logs = "2025-03-06T10:30:45.1234567Z Step 1\n2025-03-06T10:30:46.9876543Z Step 2\n";
+    const { fn } = createMockRunner([{ stdout: logs, stderr: "", exitCode: 0 }]);
+
+    const logSpy = mock(() => {});
+    const originalLog = console.log;
+    console.log = logSpy;
+
+    await getJobLogs(
+      { owner: "myorg", repo: "myrepo", jobId: "12345", stripTimestamps: false },
+      fn,
+    );
+
+    console.log = originalLog;
+    expect(logSpy).toHaveBeenCalledWith(logs);
+  });
+
+  it("should exit with error when API call fails", async () => {
+    const { fn } = createMockRunner([{ stdout: "", stderr: "Not Found", exitCode: 1 }]);
+
+    const mockExit = mock(() => {
+      throw new Error("process.exit");
+    });
+    const originalExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    try {
+      await getJobLogs({ owner: "myorg", repo: "myrepo", jobId: "99999" }, fn);
+    } catch {
+      // expected
+    }
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    process.exit = originalExit;
+  });
+});

--- a/packages/claude-tools/src/commands/gh/get-job-logs.ts
+++ b/packages/claude-tools/src/commands/gh/get-job-logs.ts
@@ -1,0 +1,69 @@
+import { type RunCommandFn, runGh, resolveRepo, parseRepoFlag } from "./repo";
+
+export interface GetJobLogsOptions {
+  owner: string;
+  repo: string;
+  jobId: string;
+  stripTimestamps?: boolean;
+}
+
+const TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z /gm;
+
+export async function getJobLogs(
+  options: GetJobLogsOptions,
+  runCommand: RunCommandFn = runGh,
+): Promise<void> {
+  const { owner, repo, jobId, stripTimestamps = true } = options;
+
+  const result = await runCommand(["api", `repos/${owner}/${repo}/actions/jobs/${jobId}/logs`]);
+
+  if (result.exitCode !== 0) {
+    console.error(`Failed to get job logs for ${jobId}: ${result.stderr}`);
+    process.exit(1);
+  }
+
+  const output = stripTimestamps ? result.stdout.replace(TIMESTAMP_REGEX, "") : result.stdout;
+  console.log(output);
+}
+
+export async function main(): Promise<void> {
+  const {
+    remaining: allArgs,
+    owner: flagOwner,
+    repo: flagRepo,
+  } = parseRepoFlag(process.argv.slice(2));
+  // allArgs[0] = group ("gh"), allArgs[1] = command ("get-job-logs"), rest = positional args/flags
+  const remaining = allArgs.slice(2);
+
+  let noStripTimestamps = false;
+  const positional: string[] = [];
+  for (const arg of remaining) {
+    if (arg === "--no-strip-timestamps") {
+      noStripTimestamps = true;
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (positional.length < 1) {
+    console.error(
+      "Usage: claude-tools gh get-job-logs <job_id> [--repo <owner/repo>] [--no-strip-timestamps]",
+    );
+    process.exit(1);
+  }
+
+  const jobId = positional[0];
+
+  let owner: string;
+  let repo: string;
+  if (flagOwner && flagRepo) {
+    owner = flagOwner;
+    repo = flagRepo;
+  } else {
+    const resolved = await resolveRepo();
+    owner = resolved.owner;
+    repo = resolved.repo;
+  }
+
+  await getJobLogs({ owner, repo, jobId, stripTimestamps: !noStripTimestamps });
+}

--- a/packages/claude-tools/src/commands/gh/index.ts
+++ b/packages/claude-tools/src/commands/gh/index.ts
@@ -1,6 +1,7 @@
 export const commands: Record<string, () => Promise<void>> = {
   "add-sub-issues": () => import("./add-sub-issues").then((m) => m.main()),
   "get-actions-run": () => import("./get-actions-run").then((m) => m.main()),
+  "get-job-logs": () => import("./get-job-logs").then((m) => m.main()),
   "get-release": () => import("./get-release").then((m) => m.main()),
   "list-run-jobs": () => import("./list-run-jobs").then((m) => m.main()),
   "list-sub-issues": () => import("./list-sub-issues").then((m) => m.main()),


### PR DESCRIPTION
## Summary

- Add `gh get-job-logs` command to fetch logs from a GitHub Actions job
- Timestamps (`YYYY-MM-DDTHH:MM:SS.nnnnnnnZ`) are stripped by default for cleaner output
- Use `--no-strip-timestamps` to preserve timestamps

## Test plan

- [x] `bun run check` passes (lint, typecheck, format, tests)
- [ ] Manual test: `bunx ./packages/claude-tools/src/cli.ts gh get-job-logs <job_id> --repo <owner/repo>`