### PR TITLE
feat: add supply chain attack prevention measures

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[install]
+# Reject packages published less than 7 days ago (604800 seconds)
+minimumReleaseAge = 604800

--- a/package.json
+++ b/package.json
@@ -22,5 +22,7 @@
     "oxfmt": "^0.32.0",
     "oxlint": "^0.16.7",
     "typescript": "^5.7.0"
-  }
+  },
+  "packageManager": "bun@1.3.10",
+  "trustedDependencies": []
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "minimumReleaseAge": "0 days"
+  }
 }


### PR DESCRIPTION
## Summary

- Harden `renovate.json` with `minimumReleaseAge` (7 days), `osvVulnerabilityAlerts`, `helpers:pinGitHubActionDigests`, `lockFileMaintenance`, and instant `vulnerabilityAlerts` with security label
- Add `trustedDependencies: []` and `packageManager` pinning to `package.json`
- Create `bunfig.toml` with `minimumReleaseAge` (604800s) to reject recently published packages during local installs

## Test plan

- [x] `bun run format:check` passes
- [x] `bun install --frozen-lockfile` works
- [ ] CI passes