### PR TITLE
chore: assign nownabe to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "assignees": ["nownabe"],
   "labels": ["renovate"],
   "minimumReleaseAge": "7 days",
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
## Summary
- Add `assignees` config to `renovate.json` so that Renovate PRs are automatically assigned to nownabe

## Test plan
- [ ] Verify next Renovate PR has nownabe assigned