### PR TITLE
refactor(claude-tools): remove --jq option from get-release

### DIFF
--- a/docs/claude-tools/gh/get-release.md
+++ b/docs/claude-tools/gh/get-release.md
@@ -1,11 +1,11 @@
 # `gh get-release`
 
-Get release information from a GitHub repository. Fetches the latest release by default, or a specific release by tag. Supports `--jq` for filtering output.
+Get release information from a GitHub repository. Fetches the latest release by default, or a specific release by tag. Pipe through `jq` to filter output.
 
 ## Usage
 
 ```bash
-claude-tools gh get-release [--tag <tag>] [--jq <expression>] [--repo <owner/repo>]
+claude-tools gh get-release [--tag <tag>] [--repo <owner/repo>]
 ```
 
 ## Options
@@ -13,13 +13,12 @@ claude-tools gh get-release [--tag <tag>] [--jq <expression>] [--repo <owner/rep
 | Option                | Required | Description                                                                |
 | --------------------- | -------- | -------------------------------------------------------------------------- |
 | `--tag <tag>`         | No       | Fetch a specific release by tag. If omitted, fetches the latest release    |
-| `--jq <expression>`   | No       | Filter the output using a jq expression                                    |
 | `--repo <owner/repo>` | No       | Target repository. If omitted, detected from the current working directory |
 
 ## Examples
 
 ```bash
 claude-tools gh get-release
-claude-tools gh get-release --jq '.tag_name'
-claude-tools gh get-release --tag v1.0.0 --jq '.body' --repo myorg/myrepo
+claude-tools gh get-release | jq '.tag_name'
+claude-tools gh get-release --tag v1.0.0 --repo myorg/myrepo | jq '.body'
 ```

--- a/packages/claude-tools/src/commands/gh/get-release.test.ts
+++ b/packages/claude-tools/src/commands/gh/get-release.test.ts
@@ -14,7 +14,7 @@ function createMockRunner(responses: { stdout: string; stderr: string; exitCode:
 }
 
 describe("getRelease", () => {
-  it("should get the latest release with default jq", async () => {
+  it("should get the latest release", async () => {
     const { fn, calls } = createMockRunner([
       {
         stdout: JSON.stringify({ tag_name: "v1.0.0", name: "Release 1.0.0" }),
@@ -27,23 +27,7 @@ describe("getRelease", () => {
 
     expect(result).toBe(JSON.stringify({ tag_name: "v1.0.0", name: "Release 1.0.0" }));
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual(["api", "repos/owner/repo/releases/latest", "--jq", "."]);
-  });
-
-  it("should get the latest release with custom jq", async () => {
-    const { fn, calls } = createMockRunner([
-      {
-        stdout: "v1.0.0",
-        stderr: "",
-        exitCode: 0,
-      },
-    ]);
-
-    const result = await getRelease({ repo: "owner/repo", jq: ".tag_name" }, fn);
-
-    expect(result).toBe("v1.0.0");
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual(["api", "repos/owner/repo/releases/latest", "--jq", ".tag_name"]);
+    expect(calls[0]).toEqual(["api", "repos/owner/repo/releases/latest"]);
   });
 
   it("should get a release by tag", async () => {
@@ -59,7 +43,7 @@ describe("getRelease", () => {
 
     expect(result).toBe(JSON.stringify({ tag_name: "v2.0.0", body: "Release notes" }));
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual(["api", "repos/myorg/myrepo/releases/tags/v2.0.0", "--jq", "."]);
+    expect(calls[0]).toEqual(["api", "repos/myorg/myrepo/releases/tags/v2.0.0"]);
   });
 
   it("should exit with error when the API call fails", async () => {

--- a/packages/claude-tools/src/commands/gh/get-release.ts
+++ b/packages/claude-tools/src/commands/gh/get-release.ts
@@ -3,18 +3,17 @@ import { type RunCommandFn, runGh, resolveRepo, parseRepoFlag } from "./repo";
 export interface GetReleaseOptions {
   repo: string;
   tag?: string;
-  jq?: string;
 }
 
 export async function getRelease(
   options: GetReleaseOptions,
   runCommand: RunCommandFn = runGh,
 ): Promise<string> {
-  const { repo, tag, jq = "." } = options;
+  const { repo, tag } = options;
 
   const endpoint = tag ? `repos/${repo}/releases/tags/${tag}` : `repos/${repo}/releases/latest`;
 
-  const result = await runCommand(["api", endpoint, "--jq", jq]);
+  const result = await runCommand(["api", endpoint]);
 
   if (result.exitCode !== 0) {
     const target = tag ? `tag "${tag}"` : "latest release";
@@ -35,20 +34,12 @@ export async function main(): Promise<void> {
   const remaining = allArgs.slice(2);
 
   let tag: string | undefined;
-  let jq: string | undefined;
 
   for (let i = 0; i < remaining.length; i++) {
     if (remaining[i] === "--tag") {
       tag = remaining[i + 1];
       if (!tag) {
         console.error("--tag requires a value");
-        process.exit(1);
-      }
-      i++;
-    } else if (remaining[i] === "--jq") {
-      jq = remaining[i + 1];
-      if (!jq) {
-        console.error("--jq requires a value");
         process.exit(1);
       }
       i++;
@@ -63,6 +54,6 @@ export async function main(): Promise<void> {
     repo = `${resolved.owner}/${resolved.repo}`;
   }
 
-  const output = await getRelease({ repo, tag, jq });
+  const output = await getRelease({ repo, tag });
   console.log(output);
 }


### PR DESCRIPTION
## Summary
- Remove the built-in `--jq` option from `gh get-release` command
- Users should pipe output through the `jq` command instead (e.g. `claude-tools gh get-release | jq '.tag_name'`)
- Update docs and tests accordingly

## Test plan
- [x] `bun run check` passes