### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to the Release workflow so it can be manually re-run via `gh workflow run` or the GitHub UI

This would have helped when the changeset release PR got stuck due to a stale `changeset-release/main` branch.

## Test plan

- [x] `actionlint` passes