### PR TITLE
feat(claude-tools): add gh get-pr-comments command

### DIFF
--- a/.changeset/calm-comics-tickle.md
+++ b/.changeset/calm-comics-tickle.md
@@ -1,0 +1,5 @@
+---
+"@nownabe/claude-tools": minor
+---
+
+Add `gh get-pr-comments` command to retrieve pull request review comments

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ bunx @nownabe/claude-tools <command>
 | `gh add-sub-issues`   | Add sub-issues to a parent GitHub issue          |
 | `gh get-actions-run`  | Get GitHub Actions workflow run information      |
 | `gh get-job-logs`     | Get logs from a GitHub Actions job               |
+| `gh get-pr-comments`  | Get review comments on a pull request            |
 | `gh get-release`      | Get release information from a GitHub repository |
 | `gh get-repo-content` | Get file content from a GitHub repository        |
 | `gh list-run-jobs`    | List jobs from a GitHub Actions workflow run     |

--- a/docs/claude-tools/gh/get-pr-comments.md
+++ b/docs/claude-tools/gh/get-pr-comments.md
@@ -1,0 +1,26 @@
+# `gh get-pr-comments`
+
+Get review comments on a pull request.
+
+## Usage
+
+```bash
+claude-tools gh get-pr-comments <pr_number> [--repo <owner/repo>]
+```
+
+## Arguments
+
+| Argument              | Required | Description                                                                |
+| --------------------- | -------- | -------------------------------------------------------------------------- |
+| `pr_number`           | Yes      | The pull request number to retrieve comments for                           |
+| `--repo <owner/repo>` | No       | Target repository. If omitted, detected from the current working directory |
+
+## Examples
+
+```bash
+# Get comments on PR #42 in the current repository
+claude-tools gh get-pr-comments 42
+
+# Get comments on PR #26 in a specific repository
+claude-tools gh get-pr-comments 26 --repo nownabe/graphein
+```

--- a/packages/claude-tools/README.md
+++ b/packages/claude-tools/README.md
@@ -19,6 +19,7 @@ bunx @nownabe/claude-tools <command>
 | [`gh add-sub-issues`](../../docs/claude-tools/gh/add-sub-issues.md)     | Add sub-issues to a parent GitHub issue          |
 | [`gh get-actions-run`](../../docs/claude-tools/gh/get-actions-run.md)   | Get GitHub Actions workflow run information      |
 | [`gh get-job-logs`](../../docs/claude-tools/gh/get-job-logs.md)         | Get logs from a GitHub Actions job               |
+| [`gh get-pr-comments`](../../docs/claude-tools/gh/get-pr-comments.md)   | Get review comments on a pull request            |
 | [`gh get-release`](../../docs/claude-tools/gh/get-release.md)           | Get release information from a GitHub repository |
 | [`gh get-repo-content`](../../docs/claude-tools/gh/get-repo-content.md) | Get file content from a GitHub repository        |
 | [`gh list-run-jobs`](../../docs/claude-tools/gh/list-run-jobs.md)       | List jobs from a GitHub Actions workflow run     |

--- a/packages/claude-tools/src/commands/gh/get-pr-comments.test.ts
+++ b/packages/claude-tools/src/commands/gh/get-pr-comments.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, mock } from "bun:test";
+import { getPrComments } from "./get-pr-comments";
+
+function createMockRunner(responses: { stdout: string; stderr: string; exitCode: number }[]) {
+  let callIndex = 0;
+  const calls: string[][] = [];
+  const fn = mock(async (args: string[]) => {
+    calls.push(args);
+    const response = responses[callIndex];
+    callIndex++;
+    return response;
+  });
+  return { fn, calls };
+}
+
+describe("getPrComments", () => {
+  it("should get comments for a pull request", async () => {
+    const comments = [
+      { id: 1, body: "Looks good!", user: { login: "reviewer" } },
+      { id: 2, body: "Please fix this", user: { login: "maintainer" } },
+    ];
+    const { fn, calls } = createMockRunner([
+      { stdout: JSON.stringify(comments), stderr: "", exitCode: 0 },
+    ]);
+
+    const result = await getPrComments({ owner: "myorg", repo: "myrepo", prNumber: 42 }, fn);
+
+    expect(result).toBe(JSON.stringify(comments));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["api", "repos/myorg/myrepo/pulls/42/comments"]);
+  });
+
+  it("should exit with error when the API call fails", async () => {
+    const { fn } = createMockRunner([{ stdout: "", stderr: "Not Found", exitCode: 1 }]);
+
+    const mockExit = mock(() => {
+      throw new Error("process.exit");
+    });
+    const originalExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    try {
+      await getPrComments({ owner: "owner", repo: "repo", prNumber: 99 }, fn);
+    } catch {
+      // expected
+    }
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    process.exit = originalExit;
+  });
+});

--- a/packages/claude-tools/src/commands/gh/get-pr-comments.ts
+++ b/packages/claude-tools/src/commands/gh/get-pr-comments.ts
@@ -1,0 +1,56 @@
+import { type RunCommandFn, runGh, resolveRepo, parseRepoFlag } from "./repo";
+
+export interface GetPrCommentsOptions {
+  owner: string;
+  repo: string;
+  prNumber: number;
+}
+
+export async function getPrComments(
+  options: GetPrCommentsOptions,
+  runCommand: RunCommandFn = runGh,
+): Promise<string> {
+  const { owner, repo, prNumber } = options;
+
+  const result = await runCommand(["api", `repos/${owner}/${repo}/pulls/${prNumber}/comments`]);
+
+  if (result.exitCode !== 0) {
+    console.error(
+      `Failed to get comments for PR #${prNumber} in ${owner}/${repo}: ${result.stderr}`,
+    );
+    process.exit(1);
+  }
+
+  return result.stdout;
+}
+
+export async function main(): Promise<void> {
+  const {
+    remaining: allArgs,
+    owner: flagOwner,
+    repo: flagRepo,
+  } = parseRepoFlag(process.argv.slice(2));
+  const remaining = allArgs.slice(2);
+
+  const prNumberStr = remaining[0];
+  if (!prNumberStr || Number.isNaN(Number(prNumberStr))) {
+    console.error("Usage: claude-tools gh get-pr-comments <pr_number> [--repo <owner/repo>]");
+    process.exit(1);
+  }
+
+  const prNumber = Number(prNumberStr);
+
+  let owner: string;
+  let repo: string;
+  if (flagOwner && flagRepo) {
+    owner = flagOwner;
+    repo = flagRepo;
+  } else {
+    const resolved = await resolveRepo();
+    owner = resolved.owner;
+    repo = resolved.repo;
+  }
+
+  const output = await getPrComments({ owner, repo, prNumber });
+  console.log(output);
+}

--- a/packages/claude-tools/src/commands/gh/index.ts
+++ b/packages/claude-tools/src/commands/gh/index.ts
@@ -2,6 +2,7 @@ export const commands: Record<string, () => Promise<void>> = {
   "add-sub-issues": () => import("./add-sub-issues").then((m) => m.main()),
   "get-actions-run": () => import("./get-actions-run").then((m) => m.main()),
   "get-job-logs": () => import("./get-job-logs").then((m) => m.main()),
+  "get-pr-comments": () => import("./get-pr-comments").then((m) => m.main()),
   "get-release": () => import("./get-release").then((m) => m.main()),
   "get-repo-content": () => import("./get-repo-content").then((m) => m.main()),
   "list-run-jobs": () => import("./list-run-jobs").then((m) => m.main()),


### PR DESCRIPTION
## Summary
- Add `gh get-pr-comments <pr_number>` command equivalent to `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments`
- Follows existing command patterns with `--repo` flag support and auto-detection

## Test plan
- [x] Unit tests pass (`bun run check`)
- [ ] Manual test: `bunx @nownabe/claude-tools gh get-pr-comments <pr_number>`

Closes #115