### PR TITLE
feat(claude-tools): add gh get-pr-reviews command

### DIFF
--- a/.changeset/add-get-pr-reviews.md
+++ b/.changeset/add-get-pr-reviews.md
@@ -1,0 +1,5 @@
+---
+"@nownabe/claude-tools": minor
+---
+
+Add `gh get-pr-reviews` command to get pull request reviews

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ bunx @nownabe/claude-tools <command>
 | `gh get-actions-run`  | Get GitHub Actions workflow run information      |
 | `gh get-job-logs`     | Get logs from a GitHub Actions job               |
 | `gh get-pr-comments`  | Get review comments on a pull request            |
+| `gh get-pr-reviews`   | Get reviews on a pull request                    |
 | `gh get-release`      | Get release information from a GitHub repository |
 | `gh get-repo-content` | Get file content from a GitHub repository        |
 | `gh list-run-jobs`    | List jobs from a GitHub Actions workflow run     |

--- a/docs/claude-tools/gh/get-pr-reviews.md
+++ b/docs/claude-tools/gh/get-pr-reviews.md
@@ -1,0 +1,26 @@
+# `gh get-pr-reviews`
+
+Get reviews on a pull request.
+
+## Usage
+
+```bash
+claude-tools gh get-pr-reviews <pull_number> [--repo <owner/repo>]
+```
+
+## Arguments
+
+| Argument              | Required | Description                                                                |
+| --------------------- | -------- | -------------------------------------------------------------------------- |
+| `pull_number`         | Yes      | The pull request number to retrieve reviews for                            |
+| `--repo <owner/repo>` | No       | Target repository. If omitted, detected from the current working directory |
+
+## Examples
+
+```bash
+# Get reviews on PR #42 in the current repository
+claude-tools gh get-pr-reviews 42
+
+# Get reviews on PR #26 in a specific repository
+claude-tools gh get-pr-reviews 26 --repo nownabe/graphein
+```

--- a/packages/claude-tools/README.md
+++ b/packages/claude-tools/README.md
@@ -20,6 +20,7 @@ bunx @nownabe/claude-tools <command>
 | [`gh get-actions-run`](../../docs/claude-tools/gh/get-actions-run.md)   | Get GitHub Actions workflow run information      |
 | [`gh get-job-logs`](../../docs/claude-tools/gh/get-job-logs.md)         | Get logs from a GitHub Actions job               |
 | [`gh get-pr-comments`](../../docs/claude-tools/gh/get-pr-comments.md)   | Get review comments on a pull request            |
+| [`gh get-pr-reviews`](../../docs/claude-tools/gh/get-pr-reviews.md)     | Get reviews on a pull request                    |
 | [`gh get-release`](../../docs/claude-tools/gh/get-release.md)           | Get release information from a GitHub repository |
 | [`gh get-repo-content`](../../docs/claude-tools/gh/get-repo-content.md) | Get file content from a GitHub repository        |
 | [`gh list-run-jobs`](../../docs/claude-tools/gh/list-run-jobs.md)       | List jobs from a GitHub Actions workflow run     |

--- a/packages/claude-tools/src/commands/gh/get-pr-reviews.test.ts
+++ b/packages/claude-tools/src/commands/gh/get-pr-reviews.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, mock } from "bun:test";
+import { getPrReviews } from "./get-pr-reviews";
+
+function createMockRunner(responses: { stdout: string; stderr: string; exitCode: number }[]) {
+  let callIndex = 0;
+  const calls: string[][] = [];
+  const fn = mock(async (args: string[]) => {
+    calls.push(args);
+    const response = responses[callIndex];
+    callIndex++;
+    return response;
+  });
+  return { fn, calls };
+}
+
+describe("getPrReviews", () => {
+  it("should call gh api with correct endpoint and output result", async () => {
+    const reviewsJson = JSON.stringify([
+      { id: 1, user: { login: "reviewer1" }, state: "APPROVED", body: "LGTM" },
+      { id: 2, user: { login: "reviewer2" }, state: "CHANGES_REQUESTED", body: "Please fix" },
+    ]);
+    const { fn, calls } = createMockRunner([{ stdout: reviewsJson, stderr: "", exitCode: 0 }]);
+
+    await getPrReviews({ owner: "myorg", repo: "myrepo", pullNumber: 26 }, fn);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["api", "repos/myorg/myrepo/pulls/26/reviews"]);
+  });
+
+  it("should exit with error when API call fails", async () => {
+    const { fn } = createMockRunner([{ stdout: "", stderr: "Not Found", exitCode: 1 }]);
+
+    const mockExit = mock(() => {
+      throw new Error("process.exit");
+    });
+    const originalExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    try {
+      await getPrReviews({ owner: "myorg", repo: "myrepo", pullNumber: 999 }, fn);
+    } catch {
+      // expected
+    }
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    process.exit = originalExit;
+  });
+});

--- a/packages/claude-tools/src/commands/gh/get-pr-reviews.ts
+++ b/packages/claude-tools/src/commands/gh/get-pr-reviews.ts
@@ -1,0 +1,57 @@
+import { type RunCommandFn, runGh, resolveRepo, parseRepoFlag } from "./repo";
+
+export interface GetPrReviewsOptions {
+  owner: string;
+  repo: string;
+  pullNumber: number;
+}
+
+export async function getPrReviews(
+  options: GetPrReviewsOptions,
+  runCommand: RunCommandFn = runGh,
+): Promise<void> {
+  const { owner, repo, pullNumber } = options;
+
+  const result = await runCommand(["api", `repos/${owner}/${repo}/pulls/${pullNumber}/reviews`]);
+
+  if (result.exitCode !== 0) {
+    console.error(`Failed to get reviews for PR #${pullNumber}: ${result.stderr}`);
+    process.exit(1);
+  }
+
+  console.log(result.stdout);
+}
+
+export async function main(): Promise<void> {
+  const {
+    remaining: allArgs,
+    owner: flagOwner,
+    repo: flagRepo,
+  } = parseRepoFlag(process.argv.slice(2));
+  const remaining = allArgs.slice(2);
+
+  if (remaining.length < 1) {
+    console.error("Usage: claude-tools gh get-pr-reviews <pull_number> [--repo <owner/repo>]");
+    process.exit(1);
+  }
+
+  const pullNumber = Number(remaining[0]);
+
+  if (Number.isNaN(pullNumber)) {
+    console.error("Pull request number must be a valid integer");
+    process.exit(1);
+  }
+
+  let owner: string;
+  let repo: string;
+  if (flagOwner && flagRepo) {
+    owner = flagOwner;
+    repo = flagRepo;
+  } else {
+    const resolved = await resolveRepo();
+    owner = resolved.owner;
+    repo = resolved.repo;
+  }
+
+  await getPrReviews({ owner, repo, pullNumber });
+}

--- a/packages/claude-tools/src/commands/gh/index.ts
+++ b/packages/claude-tools/src/commands/gh/index.ts
@@ -3,6 +3,7 @@ export const commands: Record<string, () => Promise<void>> = {
   "get-actions-run": () => import("./get-actions-run").then((m) => m.main()),
   "get-job-logs": () => import("./get-job-logs").then((m) => m.main()),
   "get-pr-comments": () => import("./get-pr-comments").then((m) => m.main()),
+  "get-pr-reviews": () => import("./get-pr-reviews").then((m) => m.main()),
   "get-release": () => import("./get-release").then((m) => m.main()),
   "get-repo-content": () => import("./get-repo-content").then((m) => m.main()),
   "list-run-jobs": () => import("./list-run-jobs").then((m) => m.main()),


### PR DESCRIPTION
## Summary
- Add `gh get-pr-reviews` command to get pull request reviews via the GitHub API
- Usage: `claude-tools gh get-pr-reviews <pull_number> [--repo <owner/repo>]`

Closes #114

## Test plan
- [x] Unit tests for success and error cases
- [x] `bun run check` passes (lint, typecheck, format, tests)